### PR TITLE
Highlighter fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Builds all the open sysl files and generates output in workspace root's `.sysl-t
 
 ## Release Notes
 
+### 0.0.8
+- Total rewrite of syntax highlighter
+
 ### 0.0.7
 - Updated the syntax highlighting
 

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-sysl",
     "displayName": "vscode-sysl",
     "description": "VS Code extension for SYSL Language.",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "author": "Sahejpreet Singh",
     "publisher": "ANZ-BANK",
     "license": "Apache-2.0",

--- a/client/syntaxes/sysl.tmLanguage.json
+++ b/client/syntaxes/sysl.tmLanguage.json
@@ -1,333 +1,559 @@
 {
-  "name": "Sysl",
-  "scopeName": "source.sysl",
-  "patterns": [
-    { "include": "#import-stmt" },
-    { "include": "#comments" },
-    { "include": "#application" }
-  ],
-  "repository": {
-    "import-stmt": {
-      "match": "^\\b(import)\\b(.*)$",
-      "name": "keyword.control.sysl",
-      "captures": {
-        "2": {
-          "name": "variable.parameter.import.path"
-        }
-      }
-    },
-    "comments": {
-      "name": "comment.line.hash.sysl",
-      "match": "[ \t]*(#|\\|).*$"
-    },
-    "application": {
-      "name": "meta.type.application.sysl",
-      "begin": "^(\\w[^\"\\[]+)(?=[^\n]*: *$)",
-      "end": "^(?=\\w)",
-      "captures": {
-        "1": {
-          "name": "entity.name.type.sysl"
-        }
-      },
-      "contentName": "meta.tag.application.sysl",
-      "patterns": [
-        { "include": "#definition-keywords"},
-        { "include": "#brackets" },
-        { "include": "#comments" },
-        { "include": "#annotation" },
-        { "include": "#http-endpoint" },
-        { "include": "#view" },
-        { "include": "#enum" },
-        { "include": "#abstract-view" },
-        { "include": "#type" },
-        { "include": "#alias" },
-        { "include": "#endpoint" },
-        { "include": "#wrap" },
-        { "include": "#string_doubleQuote" },
-        { "include": "#string_singleQuote"}
-      ]
-    },
-    "alias": {
-      "name": "meta.type.application.alias",
-      "begin": "^([ ]+|\t)(!alias) +(\\w+)[^\n:]+:",
-      "beginCaptures": {
-        "2": {
-          "name": "keyword.other.application.alias"
-        }
-      },
-      "end": "^\\1\\1(sequence of|set of)? *(\\w+)$",
-      "endCaptures": {
-        "1": {"name": "keyword.other" },
-        "2": {"name": "support.type.alias.of" }
-      },
-      "patterns": [
-        { "include": "#comments" }
-      ]
-    },
-    "type": {
-      "name": "meta.type.application.type",
-      "begin": "^([ \t]+)(!type|!table)( )+(\\w+)( )*:( )*",
-      "beginCaptures": {
-        "2": { "name": "keyword.other.application.type" },
-        "4": { "name": "entity.name.type.sysl" }
-      },
-      "end": "^(?=[^ \t]|(\\1[^ ]))",
-      "patterns": [
-        { "include": "#operators" },
-        { "include": "#comments" },
-        { "include": "#datatype" },
-        { "include": "#number_decimal" },
-        { "include": "#brackets" },
-        { "include": "#annotation" },
-        { "include": "#flow-control" },
-        { "include": "#string_singleQuote"},
-        { "include": "#string_doubleQuote" }
-      ]
-    },
-    "enum": {
-      "name": "meta.type.application.enum.sysl",
-      "begin": "^([ \t]+)(!enum)( )+(\\w[^\"\\[]+)(?=[^\n]*: *$)",
-      "beginCaptures": {
-        "2": { "name": "keyword.other.application.type.enum.sysl" },
-        "4": { "name": "entity.name.type.sysl" }
-      },
-      "end": "^(?=[^ \t]|(\\1[^ ]))",
-      "patterns": [
-        { "include": "#enum-statement" },
-        { "include": "#comments" },
-        { "include": "#number_decimal" },
-        { "include": "#brackets" }
-      ]
-    },
-    "wrap": {
-      "begin": "^([ \t]+)(!wrap)( )+(\\w+)(?=[^:]*: *$)",
-      "end": "^(?=[^ \t]|(\\1[^ ]))",
-      "beginCaptures": {
-        "2": { "name": "keyword.other.application.type" },
-        "4": { "name": "entity.name.type.sysl" }
-      },
-      "patterns": [
-        { "include": "#comments" },
-        { "include": "#brackets" },
-        { "include": "#wrap-statement"}
-      ]
-    },
-    "view": {
-      "name": "meta.type.application.view",
-      "begin": "^([ \t]+)(!view) +(\\w+)(?=\\([^)]+\\) *[^:]*:$)",
-      "end": "^\\1\\1\\)[ \t]*$",
-      "beginCaptures": {
-        "2": { "name": "keyword.other.application.view" },
-        "3": { "name": "support.type.view.name" },
-        "4": { "name": "keyword.control.return.type" },
-        "5": { "name": "support.type.view.return.type" }
-      },
-      "patterns": [
-        { "include": "#annotation" },
-        { "include": "#operators" },
-        { "include": "#number_decimal" },
-        { "include": "#comments" },
-        { "include": "#brackets" },
-        { "include": "#annotation" },
-        { "include": "#flow-control" },
-        { "include": "#view-keywords" },
-        { "include": "#view-functions" },
-        { "include": "#view-constants" },
-        {"include": "#string_singleQuote"},
-        {"include": "#string_doubleQuote"}
-      ]
-    },
-    "abstract-view": {
-      "name": "meta.type.application.abstract.view",
-      "match": "^([ \t]+)(!view) +(\\w+)(?=\\([^)]+\\) +(->) +[^\\[]+\\[.abstract\\]$)",
-      "captures": {
-        "2": { "name": "keyword.other.application.view" },
-        "3": { "name": "support.type.view.name" },
-        "4": { "name": "keyword.control.return.type" },
-        "5": { "name": "support.type.view.return.type" }
-      }
-    },
-
-    "endpoint": {
-      "begin": "^([ \t]+)(\\w[^\"\\[(]*)(?=[^\n]*: *(\\.\\.\\.)?$)",
-      "end": "^(?=[^ \t\n#]|\\1[^ \t#])",
-      "name": "meta.type.endpoint.sysl",
-      "beginCaptures": {
-        "2": {
-          "comments": "non-REST endpoint name",
-          "name": "entity.name.endpoint.sysl"
-        },
-        "3": { "name": "string.quoted.double.endpoint.longname" }
-      },
-      "patterns": [
-        { "include": "#annotation" },
-        { "include": "#http-endpoint" },
-        { "include": "#brackets" },
-        { "include": "#operators" },
-        { "include": "#string_doubleQuote" },
-        { "include": "#comments" }
-      ]
-    },
-    "http-endpoint": {
-      "begin": "^([ \t]+)(/[^{\"\\[(]*)(?=[^\n]*: *$)",
-      "end": "^(?=[^ \t\n]|(\\1[^# \t]))",
-      "name": "meta.type.http.sysl",
-      "beginCaptures": {
-        "2": {
-          "name": "entity.name.endpoint.sysl"
-        }
-      },
-      "patterns": [
-        { "include": "#annotation" },
-        { "include": "#comments" },
-        { "include": "#flow-control" },
-        { "include": "#http-method" }
-      ]
-    },
-    "http-method": {
-      "begin": "^([ \t]+)(GET|POST|PUT|PATCH|DELETE):",
-      "end": "^(?=[^ \t]|(\\1[^ \t]))",
-      "name": "meta.type.http.method.sysl",
-      "beginCaptures": {
-        "2": {
-          "name": "keyword.control.application.http.method"
-        }
-      },
-      "patterns": [
-        {"include": "#annotation" },
-        {"include": "#comments" },
-        {"include": "#operators" },
-        {"include": "#brackets" },
-        {"include": "#datatype" },
-        {"include": "#flow-control" },
-        {"include": "#string_doubleQuote" }
-      ]
-    },
-    "datatype": {
-      "name": "support.type",
-      "match": "\\b(int(32|64)?|float|any|string|xml|bool|datetime|uuid|date|decimal)\\b"
-    },
-    "view-keywords": {
-      "name": "keyword.other",
-      "match": "\\b(sequence of|set of|let|table of)\\b"
-    },
-    "view-functions": {
-      "name": "support.function.sysl.view",
-      "match": "\\b(max|sum|min|snapshot|singleOrNull|count|autoinc|substr)\\b"
-    },
-    "view-constants": {
-      "name": "support.constant.sysl.view",
-      "match": "\\b(true|false|null)\\b"
-    },
-    "flow-control": {
-      "name": "keyword.control",
-      "match": "\\b(return|[fF][oO][rR]|[Oo]ne [Oo]f|[Ll]oop|[Uu]ntil|[Ww]hile|alt|[Ii]f|[Ee]lse)\\b"
-    },
-    "definition-keywords": {
-      "name": "keyword.other.sysl",
-      "match": "(!union|!type|!wrap|!table|!view|!alias|!enum)"
-    },
-    "annotation": {
-      "name": "entity.name.tag",
-      "match": "@\\S+"
-    },
-    "operators": {
-      "name": "keyword.control.sysl",
-      "match": ":|-\\|>|=:|<:|=|\\?|<->|\\.\\.\\.|->|<-|!|~>|\\.\\.\\."
-    },
-    "string_doubleQuote": {
-      "match": "\"(?:\\\\.|[^\"])*\"?",
-      "name": "string.quoted.double"
-    },
-    "expression": {
-      "name": "constant.character.escape",
-      "begin": "%\\(",
-      "end": "\\)",
-      "patterns": [
-        { "include": "#operators" },
-        { "include": "#vars" }
-      ]
-    },
-    "ternary-expr": {
-      "name": "constant.other.id",
-      "begin": "?"
-    },
-    "vars": {
-      "name": "constant.other.id",
-      "match": "@\\S+"
-    },
-    "string_singleQuote": {
-      "match": "'(?:\\\\.|[^'])*'?",
-      "name": "string.quoted.single"
-    },
-    "parens": {
-      "name": "punctuation.section",
-      "begin": "\\(",
-      "end": "\\)",
-      "patterns": [
+    "name": "Sysl",
+    "scopeName": "source.sysl",
+    "patterns": [
         {
-          "include": "#number_decimal"
+            "include": "#import-stmt"
+        },
+        {
+            "include": "#comments"
+        },
+        {
+            "include": "#comments-docstring"
+        },
+        {
+            "include": "#application"
         }
-      ]
-    },
-    "number_decimal": {
-      "match": "\\b-?(?:\\.\\d+|\\d+\\.?\\d*)(?:[eE][+-]?\\d+)?\\b",
-      "name": "constant.numeric.number"
-    },
-    "pattern": {
-      "match": "~[_0-9+a-zA-Z]+",
-      "name": "entity.name.tag"
-    },
-    "formatted_string_doubleQuote": {
-      "begin": "\"",
-      "end": "\"",
-      "name": "string.quoted.double",
-      "patterns": [
-        { "include": "#format-operators" }
-      ]
-    },
-    "format-operators": {
-      "name": "keyword.control.sysl",
-      "match": "\\?|//|\\(|\\)|<|>|%|=="
-    },
-    "brackets": {
-      "begin": "\\[",
-      "end": "\\]",
-      "name": "punctuation.section.application.attributes",
-      "patterns": [
-        { "include": "#attribute-var"},
-        { "include": "#operators" },
-        { "include": "#pattern" },
-        { "include": "#string_singleQuote" },
-        { "include": "#formatted_string_doubleQuote" }
-      ]
-    },
-    "attribute-var": {
-      "name": "entity.name.tag.sysl",
-      "match": "\\w+(?==)"
-    },
-    "escaped-endpoint-char": {
-      "name": "constant.character.escape.sysl",
-      "match": "%[a-fA-F0-9][a-fA-F0-9]"
-    },
-    "wrap-statement": {
-      "comments": "used in wrap",
-      "begin": "^([ \t]+)(!table|!type|!union) \\w+\\s*(:\\s*\\n+)?",
-      "end": "(^(?=[^ \t\n#]|\\1[^ \t#])|\n)",
-      "beginCaptures": {
-        "2": { "name": "keyword.other.sysl"},
-        "4": { "name": "entity.name.type.sysl"}
-      },
-      "patterns": [
-        { "include": "#brackets" }
-      ]
-    },
-    "enum-statement": {
-      "comments": "used in enum",
-      "match": "^([ \t]+)(\\w+)(\\s*):(\\s*)(?=[1-9][0-9]+\\s*\\n)",
-      "captures": {
-        "2": { "name": "entity.name.other.attribute-name" }
-      }
+    ],
+    "repository": {
+        "import-stmt": {
+            "match": "^\\b(import)\\b([^\n#]*)",
+            "name": "keyword.control.sysl",
+            "captures": {
+                "2": {
+                    "name": "variable.parameter.import.path"
+                }
+            }
+        },
+        "comments": {
+            "name": "comment.line.number-sign.sysl",
+            "match": "[ \t]*(#).*$"
+        },
+        "comments-docstring": {
+            "name": "comment.line.character.docstring.sysl",
+            "match": "^[ \t]*(\\|).*$"
+        },
+        "application": {
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#comments-docstring"
+                },
+                {
+                    "include": "#string-double-quote"
+                },
+                {
+                    "include": "#string-single-quote"
+                },
+                {
+                    "include": "#transform"
+                },
+                {
+                    "include": "params"
+                },
+                {
+                    "include": "#query-params"
+                },
+                {
+                    "include": "#range"
+                },
+                {
+                    "include": "#collector"
+                },
+                {
+                    "include": "#annotation"
+                },
+                {
+                    "include": "#type-definitions"
+                },
+                {
+                    "include": "#event-decl"
+                },
+                {
+                    "include": "#subscribe"
+                },
+                {
+                    "include": "#operators"
+                },
+                {
+                    "include": "#collection-type"
+                },
+                {
+                    "include": "#datatype"
+                },
+                {
+                    "include": "#brackets"
+                },
+                {
+                    "include": "#flow-control"
+                },
+                {
+                    "include": "#number-decimal"
+                },
+                {
+                    "include": "#generic-app-def"
+                },
+                {
+                    "include": "#http-verbs"
+                },
+                {
+                    "include": "#rest-endpoint-name"
+                },
+                {
+                    "include": "#single-dot"
+                },
+                {
+                    "include": "#package-name"
+                },
+                {
+                    "include": "#app-reference"
+                },
+                {
+                    "include": "#field-assignment"
+                },
+                {
+                    "include": "#enum-assignment"
+                },
+                {
+                    "include": "#mixin"
+                }
+            ]
+        },
+        "annotation": {
+            "match": "@[-\\w.]+",
+            "name": "entity.name.tag.sysl"
+        },
+        "string-double-quote": {
+            "match": "\"(?:\\\\.|[^\"])*\"?",
+            "name": "string.quoted.double"
+        },
+        "string-single-quote": {
+            "match": "'(?:\\\\.|[^'])*'?",
+            "name": "string.quoted.single"
+        },
+        "operators": {
+            "name": "keyword.control.sysl",
+            "match": "::|-\\|>|=:|<:|=|\\?|<->|\\.\\.\\.|->|<-|!|~>|\\.\\.\\."
+        },
+        "type-definitions": {
+            "name": "meta.type-definition.sysl",
+            "match": "(!union|!type|!wrap|!table|!view|!alias|!enum)((?:[ \t]+)[-\\w.]+)?",
+            "captures": {
+                "1": {
+                    "name": "keyword.other.sysl"
+                },
+                "2": {
+                    "name": "entity.name.type.sysl"
+                }
+            }
+        },
+        "datatype": {
+            "name": "support.type.sysl",
+            "match": "\\b(int(32|64)?|float|any|string|xml|bool|datetime|uuid|date|decimal)\\b"
+        },
+        "collection-type": {
+            "name": "keyword.other.collection-type.sysl",
+            "match": "\\b(set of|sequence of)\\b"
+        },
+        "brackets": {
+            "begin": "\\[",
+            "end": "\\]",
+            "name": "punctuation.section.application.attributes",
+            "patterns": [
+                {
+                    "include": "#brackets"
+                },
+                {
+                    "include": "#attribute-var"
+                },
+                {
+                    "include": "#operators"
+                },
+                {
+                    "include": "#abstract"
+                },
+                {
+                    "include": "#tilde"
+                },
+                {
+                    "include": "#string-single-quote"
+                },
+                {
+                    "include": "#formatted-string-double-quote"
+                }
+            ]
+        },
+        "abstract": {
+            "match": "~abstract",
+            "name": "constant.other.abstract.sysl"
+        },
+        "tilde": {
+            "match": "~[-._0-9+a-zA-Z]+",
+            "name": "entity.name.tag.sysl"
+        },
+        "attribute-var": {
+            "name": "entity.name.tag.sysl",
+            "match": "[-\\w.]+(?=[ \t]*=)"
+        },
+        "formatted-string-double-quote": {
+            "begin": "\"",
+            "end": "(?<!\\\\)\"",
+            "name": "string.quoted.double.formatted.sysl",
+            "patterns": [
+                {
+                    "include": "#format-operators"
+                }
+            ]
+        },
+        "format-operators": {
+            "name": "keyword.control.sysl",
+            "match": "\\?|//|\\(|\\)|<|>|%|=="
+        },
+        "flow-control": {
+            "name": "keyword.control.sysl",
+            "match": "\\b(return|for|one of|loop|until|while|alt|if|else)\\b"
+        },
+        "number-decimal": {
+            "match": "\\b-?(?:\\.\\d+|\\d+\\.?\\d*)(?:[eE][+-]?\\d+)?\\b",
+            "name": "constant.numeric.number.sysl"
+        },
+        "rest-endpoint-name": {
+            "begin": "(/)",
+            "end": "(?<!\\<)(?=:)| |\t|(?=\\[)",
+            "name": "meta.endpoint.rest.name.sysl",
+            "captures": {
+                "1": {
+                    "name": "keyword.other.endpoint.rest.sysl"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#datatype"
+                },
+                {
+                    "include": "#escaped-endpoint-char"
+                },
+                {
+                    "include": "#invalid-escaped-endpoint-char"
+                },
+                {
+                    "include": "#rest-endpoint-path-var"
+                },
+                {
+                    "include": "#rest-endpoint-path-name"
+                },
+                {
+                    "include": "#rest-endpoint-path-separator"
+                }
+            ]
+        },
+        "rest-endpoint-path-separator": {
+            "match": "/",
+            "name": "keyword.other.endpoint.rest.sysl"
+        },
+        "rest-endpoint-path-name": {
+            "match": "[-.~\\w]+",
+            "name": "entity.name.endpoint.sysl"
+        },
+        "rest-endpoint-path-var": {
+            "name": "meta.endpoint.rest.var.sysl",
+            "begin": "{",
+            "end": "}",
+            "patterns": [
+                {
+                    "include": "#field-assignment"
+                },
+                {
+                    "include": "#datatype"
+                },
+                {
+                    "match": "<:",
+                    "name": "keyword.operator.type-assign.sysl"
+                }
+            ]
+        },
+        "escaped-endpoint-char": {
+            "name": "constant.character.escape.sysl",
+            "match": "%[a-fA-F0-9]{2}"
+        },
+        "invalid-escaped-endpoint-char": {
+            "name": "invalid.illegal.escape.sysl",
+            "match": "%([^a-fA-F0-9].?|.?[^a-fA-F0-9]?)"
+        },
+        "http-verbs":{
+            "name": "keyword.other.http-verbs.sysl",
+            "match": "\\b(GET|POST|PUT|PATCH|DELETE)\\b"
+        },
+        "query-params": {
+            "begin": "(?=\\?)",
+            "end": "(?=[ \t:\\[])",
+            "patterns": [
+                {
+                    "include": "#datatype"
+                },
+                {
+                    "match": "(=|\\?|&)",
+                    "name": "keyword.operator.query-params.sysl"
+                }
+            ]
+        },
+        "event-decl": {
+            "match": "(?<=<->)[ \t]+([-. \\w]+\\b)",
+            "name": "entity.name.type.event.sysl"
+        },
+        "params":{
+            "begin": "\\(",
+            "end": "\\)",
+            "name": "meta.params.sysl",
+            "patterns": [
+                {
+                    "include": "#assign"
+                },
+                {
+                    "include": "#datatype"
+                },
+                {
+                    "include": "#package-name"
+                },
+                {
+                    "include": "#app-reference"
+                }
+            ]
+        },
+        "mixin": {
+            "match": "(?<=-\\|>)[ \t]*([-. \\w]+\\b)",
+            "name": "entity.name.type.mixin.sysl"
+        },
+        "subscribe": {
+            "match": "[ \t]+([-. \\w]+\\b)[ \t]*(->)[ \t]*([-. \\w]+\\b)",
+            "name": "meta.subcsribe.sysl",
+            "captures": {
+                "1": {
+                    "name": "entity.name.subscriber.sysl"
+                },
+                "2": {
+                    "name": "keyword.operator.subscribe.sysl"
+                },
+                "3": {
+                    "name": "entity.other.subscribee.sysl"
+                }
+            }
+        },
+        "package-name": {
+            "match": "([-. \\w]+\\b)(?=[ \t]*::)",
+            "name": "entity.name.type.package-name.sysl"
+        },
+        "app-reference": {
+            "match": "(?<=::)[ \t]*([-. \\w]+\\b)",
+            "name": "entity.name.type.app-reference.sysl"
+        },
+        "generic-app-def": {
+            "begin": "^(?=\\w)",
+            "end": "(?<!:|<):(?!:)",
+            "name": "meta.application.def.sysl",
+            "patterns": [
+                {
+                    "include": "#string-single-quote"
+                },
+                {
+                    "include": "#string-double-quote"
+                },
+                {
+                    "include": "#brackets"
+                },
+                {
+                    "include": "#app-name"
+                }
+            ]
+        },
+        "app-name": {
+            "match": "([-.\\w ]+\\b)[ \t]*(::)?",
+            "name": "meta.application.def.name.sysl",
+            "captures": {
+                "1": {
+                    "name": "entity.name.type.app-name.sysl"
+                },
+                "2": {
+                    "name": "keyword.other.app-name-separator.sysl"
+                }
+            }
+        },
+        "field-assignment": {
+            "match": "([-.\\w]+)(?=[ \t]*(\\([^ \\)]+\\))?[ \t]*<:)",
+            "name": "entity.name.type.field.sysl"
+        },
+        "enum-assignment": {
+            "match": "^[ \t]+([-\\w]+)(?=[ \t]*:)",
+            "name": "entity.name.type.enum.sysl"
+        },
+        "range": {
+            "match": "\\(\\s*(\\d+)\\s*(\\.\\.?)\\s*(\\d*)\\s*(?=\\))",
+            "name": "meta.range.sysl",
+            "captures": {
+                "1": {
+                    "name": "constant.numeric.number.sysl"
+                },
+                "2": {
+                    "name": "keyword.other.range.sysl"
+                },
+                "3": {
+                    "name": "constant.numeric.number.sysl"
+                }
+            }
+
+        },
+        "collector": {
+            "match": ".. \\* <- \\*(?=:)",
+            "name": "keyword.other.collector.sysl"
+        },
+        "transform": {
+            "begin": "\\(\\s*(\\w*)\\s*(:)",
+            "end": "\\)",
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.transform-param.sysl"
+                },
+                "2": {
+                    "name": "keyword.other.transform.begin.sysl"
+                }
+            },
+            "name": "meta.transform.sysl",
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#comments-docstring"
+                },
+                {
+                    "include": "#string-double-quote"
+                },
+                {
+                    "include": "#string-single-quote"
+                },
+                {
+                    "include": "#transform"
+                },
+                {
+                    "include": "#range"
+                },
+                {
+                    "include": "#transform-args"
+                },
+                {
+                    "include": "#number-decimal"
+                },
+                {
+                    "include": "#collection-type"
+                },
+                {
+                    "include": "#operators"
+                },
+                {
+                    "include": "#format-operators"
+                },
+                {
+                    "include": "#brackets"
+                },
+                {
+                    "include": "#transform-keywords"
+                },
+                {
+                    "include": "#transform-funcs"
+                },
+                {
+                    "include": "#transform-literal"
+                },
+                {
+                    "include": "#transform-operator"
+                },
+                {
+                    "include": "#datatype"
+                },
+                {
+                    "include": "#single-dot"
+                }
+            ]
+        },
+        "transform-args": {
+            "begin": "\\((?!:)",
+            "end": "\\)",
+            "name": "meta.transform.args.sysl",
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#comments-docstring"
+                },
+                {
+                    "include": "#string-double-quote"
+                },
+                {
+                    "include": "#string-single-quote"
+                },
+                {
+                    "include": "#transform-args"
+                },
+                {
+                    "include": "#single-dot"
+                },
+                {
+                    "include": "#range"
+                },
+                {
+                    "include": "#number-decimal"
+                },
+                {
+                    "include": "#collection-type"
+                },
+                {
+                    "include": "#operators"
+                },
+                {
+                    "include": "#format-operators"
+                },
+                {
+                    "include": "#brackets"
+                },
+                {
+                    "include": "#transform-literal"
+                },
+                {
+                    "include": "#transform-keywords"
+                },
+                {
+                    "include": "#transform-funcs"
+                },
+                {
+                    "include": "#transform-operator"
+                },
+                {
+                    "include": "#datatype"
+                }
+            ]
+        },
+        "transform-keywords": {
+            "match": "\\b(let|but not|in|contains|\\.?table of|if|then|else|singleOrNull|single|count|snapshot|by)\\b",
+            "name": "keyword.other.transform.sysl"
+        },
+        "transform-funcs": {
+            "match": "\\.?\\b(autoinc|str|substr|asc|desc|rank|min|max|sum|average|first|where|flatten|any)\\b(?=(<[- .\\w]+>)?\\((?!:))",
+            "name": "keyword.other.transform.function.sysl"
+        },
+        "transform-operator": {
+            "match": "\\|\\||&&|\\||&|\\band\\b|\\^|\\bxor\\b|<=|>=|>|<|==|\\+|\\*|\\*\\*|\\-|\\/|\\~|\\$!",
+            "name": "keyword.operator.transform.sysl"
+        },
+        "single-dot": {
+            "match": "(?<![\\w\\)])\\.(?!\\w)",
+            "name": "keyword.other.wildcard.sysl"
+        },
+        "transform-literal": {
+            "match": "\\b(true|false|null)\\b",
+            "name": "constant.language.transform.sysl"
+        }
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vscode-sysl",
 	"description": "VS Code extension for SYSL Language.",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"author": "Sahejpreet Singh",
 	"publisher": "ANZ-BANK",
 	"license": "Apache-2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-sysl",
     "description": "VS Code extension for SYSL Language.",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "author": "Sahejpreet Singh",
     "publisher": "ANZ-BANK",
     "license": "Apache-2.0",


### PR DESCRIPTION
Fixes #26 , fixes #27, fixes, #28, fixes #29, fixes #30 

A big highlighter implementation change. It no longer relies on scope (except transform) to provide context sensitive highlighting. Now it just uses token to improve stability. This results in:
- Highlighter changes when a block ended indentation early
- Keywords and certain constructs (params, query params) are highlighted much better
- Operators are stabler and highlighted properly
- Builtin functions and keywords are highlighted in transforms

But this also results in a very forgiving highlighter.